### PR TITLE
Add access logs to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ HEALTHCHECK --interval=5s --timeout=5s --start-period=5s --retries=30 \
     CMD curl --fail http://localhost:8000/ || exit 1
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2", "--chdir", "src"]
+CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2", "--chdir", "src", "--access-logfile", "-"]


### PR DESCRIPTION
Cause esphome always downloads 0 bytes, let's start by seeing what it's asking for