### PR TITLE
chore: avoid installing packages newer than 1 week

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,4 @@ exclude = ["uv.lock"]
 
 [tool.uv]
 add-bounds = "exact"  # having exact versions in pyproject.toml works better with renovatebot to have clearer PRs
+exclude-newer = "1 week"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Django project for daily word tracking"
 requires-python = "==3.14.*"
 dependencies = [
   "django==6.0.7",
-  "django-typer[rich]==3.7.4",
+  "django-typer==3.7.4",
   "environs[django]==15.1.0",
   "gunicorn==26.0.0",
   "pillow==12.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.14.*"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = "==6.0.7" },
-    { name = "django-typer", extras = ["rich"], specifier = "==3.7.4" },
+    { name = "django-typer", specifier = "==3.7.4" },
     { name = "environs", extras = ["django"], specifier = "==15.1.0" },
     { name = "gunicorn", specifier = "==26.0.0" },
     { name = "pillow", specifier = "==12.3.0" },


### PR DESCRIPTION
Add 'exclude-newer' option to UV tool configuration.